### PR TITLE
feat: add monthly view income statement and improve large tooltip

### DIFF
--- a/internal/server/income_statement.go
+++ b/internal/server/income_statement.go
@@ -36,7 +36,8 @@ type RunningBalance struct {
 func GetIncomeStatement(db *gorm.DB) gin.H {
 	postings := query.Init(db).All()
 	statements := computeStatement(db, postings)
-	return gin.H{"yearly": statements}
+	monthlyStatements := computeMonthlyStatement(db, postings)
+	return gin.H{"yearly": statements, "monthly": monthlyStatements}
 }
 
 func computeStatement(db *gorm.DB, postings []posting.Posting) map[string]IncomeStatement {
@@ -130,6 +131,123 @@ func computeStatement(db *gorm.DB, postings []posting.Posting) map[string]Income
 	}
 
 	return statements
+}
+
+func computeMonthlyStatement(db *gorm.DB, postings []posting.Posting) map[string]map[string]IncomeStatement {
+	monthlyStatements := make(map[string]map[string]IncomeStatement)
+
+	grouped := utils.GroupByFY(postings)
+	fys := lo.Keys(grouped)
+	sort.Strings(fys)
+
+	for _, fy := range fys {
+		fyPostings := grouped[fy]
+		monthlyStatements[fy] = make(map[string]IncomeStatement)
+
+		// Group postings by month within the financial year
+		monthlyGrouped := utils.GroupByMonth(fyPostings)
+
+		// Get all months in the financial year
+		start, end := utils.ParseFY(fy)
+		current := start
+
+		runnings := make(map[string]RunningBalance)
+		startingBalance := decimal.Zero
+
+		for current.Before(end) || current.Equal(end) {
+			monthKey := current.Format("2006-01")
+			incomeStatement := IncomeStatement{}
+			incomeStatement.Date = current
+			incomeStatement.StartingBalance = startingBalance
+			incomeStatement.Income = make(map[string]decimal.Decimal)
+			incomeStatement.Interest = make(map[string]decimal.Decimal)
+			incomeStatement.Equity = make(map[string]decimal.Decimal)
+			incomeStatement.Pnl = make(map[string]decimal.Decimal)
+			incomeStatement.Liabilities = make(map[string]decimal.Decimal)
+			incomeStatement.Tax = make(map[string]decimal.Decimal)
+			incomeStatement.Expenses = make(map[string]decimal.Decimal)
+
+			monthPostings := monthlyGrouped[monthKey]
+
+			for _, p := range monthPostings {
+				category := utils.FirstName(p.Account)
+
+				switch category {
+				case "Income":
+					if service.IsCapitalGains(p) {
+						sourceAccount := service.CapitalGainsSourceAccount(p.Account)
+						r := runnings[sourceAccount]
+						if r.quantity == nil {
+							r.quantity = make(map[string]decimal.Decimal)
+						}
+						r.amount = r.amount.Add(p.Amount)
+						runnings[sourceAccount] = r
+					} else if strings.HasPrefix(p.Account, "Income:Interest") {
+						incomeStatement.Interest[p.Account] = incomeStatement.Interest[p.Account].Add(p.Amount)
+					} else {
+						incomeStatement.Income[p.Account] = incomeStatement.Income[p.Account].Add(p.Amount)
+					}
+				case "Equity":
+					incomeStatement.Equity[p.Account] = incomeStatement.Equity[p.Account].Add(p.Amount)
+				case "Expenses":
+					if strings.HasPrefix(p.Account, "Expenses:Tax") {
+						incomeStatement.Tax[p.Account] = incomeStatement.Tax[p.Account].Add(p.Amount)
+					} else {
+						incomeStatement.Expenses[p.Account] = incomeStatement.Expenses[p.Account].Add(p.Amount)
+					}
+				case "Liabilities":
+					incomeStatement.Liabilities[p.Account] = incomeStatement.Liabilities[p.Account].Add(p.Amount)
+				case "Assets":
+					r := runnings[p.Account]
+					if r.quantity == nil {
+						r.quantity = make(map[string]decimal.Decimal)
+					}
+					r.amount = r.amount.Add(p.Amount)
+					r.quantity[p.Commodity] = r.quantity[p.Commodity].Add(p.Quantity)
+					runnings[p.Account] = r
+				default:
+					// ignore
+				}
+			}
+
+			// Calculate PnL for this month
+			monthEndDate := current.AddDate(0, 1, -1) // Last day of current month
+			if monthEndDate.After(end) {
+				monthEndDate = end
+			}
+
+			for account, r := range runnings {
+				diff := r.amount.Neg()
+				for commodity, quantity := range r.quantity {
+					diff = diff.Add(service.GetPrice(db, commodity, quantity, monthEndDate))
+				}
+				if !diff.IsZero() {
+					incomeStatement.Pnl[account] = diff
+				}
+
+				r.amount = r.amount.Add(diff)
+				runnings[account] = r
+			}
+
+			startingBalance = startingBalance.
+				Add(sumBalance(incomeStatement.Income).Neg()).
+				Add(sumBalance(incomeStatement.Interest).Neg()).
+				Add(sumBalance(incomeStatement.Equity).Neg()).
+				Add(sumBalance(incomeStatement.Tax).Neg()).
+				Add(sumBalance(incomeStatement.Expenses).Neg()).
+				Add(sumBalance(incomeStatement.Pnl)).
+				Add(sumBalance(incomeStatement.Liabilities).Neg())
+
+			incomeStatement.EndingBalance = startingBalance
+
+			monthlyStatements[fy][monthKey] = incomeStatement
+
+			// Move to next month
+			current = current.AddDate(0, 1, 0)
+		}
+	}
+
+	return monthlyStatements
 }
 
 func sumBalance(breakdown map[string]decimal.Decimal) decimal.Decimal {

--- a/src/lib/components/MultiSelectMonthPicker.svelte
+++ b/src/lib/components/MultiSelectMonthPicker.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let selectedMonths: string[] = [];
+
+  const dispatch = createEventDispatcher();
+
+  const months = [
+    { value: "01", label: "January" },
+    { value: "02", label: "February" },
+    { value: "03", label: "March" },
+    { value: "04", label: "April" },
+    { value: "05", label: "May" },
+    { value: "06", label: "June" },
+    { value: "07", label: "July" },
+    { value: "08", label: "August" },
+    { value: "09", label: "September" },
+    { value: "10", label: "October" },
+    { value: "11", label: "November" },
+    { value: "12", label: "December" }
+  ];
+
+  let isOpen = false;
+  let dropdownElement: HTMLDivElement;
+
+  function toggleDropdown(event: MouseEvent) {
+    event.stopPropagation();
+    isOpen = !isOpen;
+  }
+
+  function toggleMonth(monthValue: string) {
+    if (selectedMonths.includes(monthValue)) {
+      selectedMonths = selectedMonths.filter((m) => m !== monthValue);
+    } else {
+      selectedMonths = [...selectedMonths, monthValue];
+    }
+    dispatch("change", selectedMonths);
+  }
+
+  function selectAllMonths(event: MouseEvent) {
+    event.stopPropagation();
+    selectedMonths = months.map((m) => m.value);
+    dispatch("change", selectedMonths);
+  }
+
+  function clearAllMonths(event: MouseEvent) {
+    event.stopPropagation();
+    // Select just January to keep it predictable and avoid auto-selection
+    selectedMonths = ["01"];
+    dispatch("change", selectedMonths);
+  }
+
+  function handleClickOutside(event: MouseEvent) {
+    if (dropdownElement && !dropdownElement.contains(event.target as Node)) {
+      isOpen = false;
+    }
+  }
+
+  $: selectedMonthsText = (() => {
+    if (selectedMonths.length === 0) return "Select months";
+    if (selectedMonths.length === 1) {
+      const month = months.find((m) => m.value === selectedMonths[0]);
+      return month ? month.label : selectedMonths[0];
+    }
+    if (selectedMonths.length === 12) return "All months";
+    return `${selectedMonths.length} months selected`;
+  })();
+</script>
+
+<svelte:window on:click={handleClickOutside} />
+
+<div class="dropdown is-left is-small" class:is-active={isOpen} bind:this={dropdownElement}>
+  <div class="dropdown-trigger">
+    <button
+      class="button is-small"
+      on:click={toggleDropdown}
+      type="button"
+      aria-haspopup="true"
+      aria-controls="dropdown-menu"
+    >
+      <span>{selectedMonthsText}</span>
+      <span class="icon is-small">
+        <i class="fas fa-chevron-down" class:rotated={isOpen}></i>
+      </span>
+    </button>
+  </div>
+
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <!-- Select All / Clear All buttons -->
+      <div class="dropdown-actions">
+        <button class="action-button select-all" on:click={selectAllMonths} type="button">
+          Select All
+        </button>
+        <button class="action-button clear-all" on:click={clearAllMonths} type="button">
+          Clear All
+        </button>
+      </div>
+
+      <div class="dropdown-divider"></div>
+
+      <!-- Month checkboxes -->
+      {#each months as month}
+        <label class="dropdown-item checkbox-item">
+          <input
+            type="checkbox"
+            checked={selectedMonths.includes(month.value)}
+            on:change={() => toggleMonth(month.value)}
+          />
+          <span class="checkbox-label">{month.label}</span>
+          <span class="month-code">({month.value})</span>
+        </label>
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Icon rotation animation */
+  .dropdown-trigger .icon i.rotated {
+    transform: rotate(180deg);
+  }
+
+  /* Custom dropdown content styling */
+  .dropdown-content {
+    max-height: 320px;
+    overflow-y: auto;
+  }
+
+  .dropdown-actions {
+    display: flex;
+    padding: 0.75rem;
+    gap: 0.5rem;
+    background: #f8f9fa;
+    border-bottom: 0px solid #e9ecef;
+  }
+
+  .action-button {
+    flex: 1;
+    padding: 0.375rem 0.75rem;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    background: white;
+    color: #495057;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .action-button:hover {
+    background: #e9ecef;
+    border-color: #adb5bd;
+  }
+
+  .action-button.select-all:hover {
+    background: #d4edda;
+    border-color: #c3e6cb;
+    color: #155724;
+  }
+
+  .action-button.clear-all:hover {
+    background: #f8d7da;
+    border-color: #f5c6cb;
+    color: #721c24;
+  }
+
+  .dropdown-divider {
+    height: 1px;
+    background: #e9ecef;
+    margin: 0;
+  }
+
+  .checkbox-item {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    margin: 0;
+    border-bottom: 0px solid #f8f9fa;
+  }
+
+  .checkbox-item:last-child {
+    border-bottom: none;
+  }
+
+  .checkbox-item:hover {
+    background-color: #f8f9fa;
+  }
+
+  .checkbox-item input[type="checkbox"] {
+    margin-right: 0.75rem;
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+    accent-color: #3273dc;
+  }
+
+  .checkbox-label {
+    cursor: pointer;
+    user-select: none;
+    flex: 1;
+    font-weight: 500;
+  }
+
+  .month-code {
+    color: #6c757d;
+    font-size: 0.75rem;
+    font-weight: normal;
+  }
+
+  /* Dark mode support */
+  :global(html[data-theme="dark"]) .dropdown-trigger {
+    background: #363636 !important;
+    border-color: #4a4a4a !important;
+    color: #f5f5f5 !important;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-trigger:hover {
+    border-color: #5a5a5a !important;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-menu {
+    background: #363636 !important;
+    border-color: #4a4a4a !important;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-actions {
+    background: #2a2a2a !important;
+    border-bottom: 0px solid #4a4a4a !important;
+  }
+
+  :global(html[data-theme="dark"]) .action-button {
+    background: #363636 !important;
+    border-color: #4a4a4a !important;
+    color: #f5f5f5 !important;
+  }
+
+  :global(html[data-theme="dark"]) .action-button:hover {
+    background: #4a4a4a !important;
+    border-color: #5a5a5a !important;
+  }
+
+  :global(html[data-theme="dark"]) .action-button.select-all:hover {
+    background: #1e4d2b !important;
+    border-color: #28a745 !important;
+    color: #d4edda !important;
+  }
+
+  :global(html[data-theme="dark"]) .action-button.clear-all:hover {
+    background: #4d1e1e !important;
+    border-color: #dc3545 !important;
+    color: #f8d7da !important;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-divider {
+    background: #4a4a4a !important;
+  }
+
+  :global(html[data-theme="dark"]) .checkbox-item {
+    border-bottom: 0px solid #4a4a4a !important;
+    color: #f5f5f5 !important;
+  }
+
+  :global(html[data-theme="dark"]) .checkbox-item:hover {
+    background-color: #2a2a2a !important;
+  }
+
+  :global(html[data-theme="dark"]) .month-code {
+    color: #adb5bd !important;
+  }
+</style>

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import Actions from "$lib/components/Actions.svelte";
-  import { month, year, dateMax, dateMin, dateRangeOption } from "../../store";
+  import {
+    month,
+    year,
+    viewMode,
+    selectedMonths,
+    dateMax,
+    dateMin,
+    dateRangeOption
+  } from "../../store";
   import {
     cashflowExpenseDepth,
     cashflowExpenseDepthAllowed,
@@ -16,6 +24,7 @@
   import DateRange from "./DateRange.svelte";
   import ThemeSwitcher from "./ThemeSwitcher.svelte";
   import MonthPicker from "./MonthPicker.svelte";
+  import MultiSelectMonthPicker from "./MultiSelectMonthPicker.svelte";
   import Logo from "./Logo.svelte";
   import InputRange from "./InputRange.svelte";
   export let isBurger: boolean = null;
@@ -26,6 +35,11 @@
       year.set(financialYear(now()));
     }
   });
+
+  // Auto-select all months when switching to monthly view
+  $: if ($viewMode === "monthly" && $selectedMonths.length === 0) {
+    selectedMonths.set(["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]);
+  }
 
   const RecurringIcons = [
     { icon: "fa-circle-check", color: "success", label: "Cleared" },
@@ -43,6 +57,7 @@
     dateRangeSelector?: boolean;
     monthPicker?: boolean;
     financialYearPicker?: boolean;
+    customYearMonthPicker?: boolean;
     maxDepthSelector?: boolean;
     recurringIcons?: boolean;
     children?: Link[];
@@ -54,7 +69,7 @@
       label: "Cash Flow",
       href: "/cash_flow",
       children: [
-        { label: "Income Statement", href: "/income_statement", financialYearPicker: true },
+        { label: "Income Statement", href: "/income_statement", customYearMonthPicker: true },
         { label: "Monthly", href: "/monthly", dateRangeSelector: true },
         {
           label: "Yearly",
@@ -427,6 +442,43 @@
               <option>{financialYear(fy)}</option>
             {/each}
           </select>
+        </div>
+      </div>
+    {/if}
+
+    {#if selectedSubSubLink?.customYearMonthPicker || selectedSubLink?.customYearMonthPicker || selectedLink?.customYearMonthPicker}
+      <div class="has-text-centered">
+        <div class="field has-addons">
+          <!-- Multi-select Month Dropdown (positioned on the left, only shown when monthly is selected) -->
+          {#if $viewMode === "monthly"}
+            <div class="control">
+              <MultiSelectMonthPicker
+                bind:selectedMonths={$selectedMonths}
+                on:change={(e) => selectedMonths.set(e.detail)}
+              />
+            </div>
+          {/if}
+
+          <!-- View Mode Dropdown (Yearly/Monthly) -->
+          <div class="control">
+            <div class="select is-small">
+              <select bind:value={$viewMode}>
+                <option value="yearly">Yearly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Year Dropdown -->
+          <div class="control">
+            <div class="select is-small">
+              <select bind:value={$year}>
+                {#each forEachFinancialYear($dateMin, $dateMax).reverse() as fy}
+                  <option>{financialYear(fy)}</option>
+                {/each}
+              </select>
+            </div>
+          </div>
         </div>
       </div>
     {/if}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1125,6 +1125,47 @@ export function tooltip(
   return `<table class='table is-narrow is-size-7 popup-table'><tbody>${trs}</tbody></table>`;
 }
 
+/**
+ * Generic tooltip content creator.
+ * - Sorts items by amount (descending).
+ */
+export function createTooltipContent<T>(
+  items: T[],
+  options: {
+    getAmount: (item: T) => number;
+    getLabel: (item: T) => string;
+    filterCondition?: (item: T) => boolean;
+    maxEntries?: number;
+  }
+): string {
+  const { getAmount, getLabel, filterCondition = () => true, maxEntries = 15 } = options;
+
+  // Filter items based on condition
+  const filteredItems = items.filter(filterCondition);
+  const total = _.sumBy(filteredItems, getAmount);
+
+  // Sort by amount (descending)
+  const sortedItems = _.orderBy(filteredItems, [getAmount], ["desc"]);
+
+  // Limit entries to prevent tooltip overflow
+  const shouldTruncate = sortedItems.length > maxEntries;
+  const displayItems = shouldTruncate ? sortedItems.slice(0, maxEntries) : sortedItems;
+
+  // Format tooltip rows
+  const tooltipRows = displayItems.map((item) => [
+    getLabel(item),
+    [formatCurrency(getAmount(item)), "has-text-weight-bold has-text-right"]
+  ]);
+
+  // Add truncation indicator if needed
+  if (shouldTruncate) {
+    const remainingCount = filteredItems.length - maxEntries;
+    tooltipRows.push([`... and ${remainingCount} more entries`, ["", ""]]);
+  }
+
+  return tooltip(tooltipRows, { total: formatCurrency(total) });
+}
+
 export function isMobile() {
   return window.innerWidth < 769;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -636,9 +636,10 @@ export function ajax(route: "/api/budget"): Promise<{
 }>;
 
 export function ajax(route: "/api/cash_flow"): Promise<{ cash_flows: CashFlow[] }>;
-export function ajax(
-  route: "/api/income_statement"
-): Promise<{ yearly: Record<string, IncomeStatement> }>;
+export function ajax(route: "/api/income_statement"): Promise<{
+  yearly: Record<string, IncomeStatement>;
+  monthly: Record<string, Record<string, IncomeStatement>>;
+}>;
 
 export function ajax(
   route: "/api/recurring"

--- a/src/routes/(app)/cash_flow/income_statement/+page.svelte
+++ b/src/routes/(app)/cash_flow/income_statement/+page.svelte
@@ -150,7 +150,12 @@
       diff = incomeStatement.endingBalance - incomeStatement.startingBalance;
       diffPercent = diff / incomeStatement.startingBalance;
 
-      renderer(incomeStatement);
+      renderer(incomeStatement, {
+        isMonthlyView,
+        selectedMonths: $selectedMonths,
+        monthlyData: monthly,
+        year: $year
+      });
       isEmpty = false;
     } else {
       incomeStatement = null;

--- a/src/store.ts
+++ b/src/store.ts
@@ -57,6 +57,8 @@ export const sheetEditorState = writable(initialSheetEditorState);
 
 export const month = writable(now().format("YYYY-MM"));
 export const year = writable<string>("");
+export const viewMode = writable("yearly"); // "yearly" or "monthly"
+export const selectedMonths = writable<string[]>([]);
 export const dateRangeOption = writable<number>(3);
 
 export const dateMin = writable(dayjs("1980", "YYYY"));


### PR DESCRIPTION
Changelog:
1. Add monthly view for income statement page.
2. Truncate tooltip larger than 20 entries. For tooltip with only name and amount, sort by amount, descending.

Preview (1):
![20251003-224557](https://github.com/user-attachments/assets/b480009c-5613-42d9-ad59-a91a117769af)
<img width="1270" height="856" alt="image" src="https://github.com/user-attachments/assets/251cedf8-c4e2-4430-8af8-896d2a4274c2" />


Preview (2):
Before:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/ad760610-363b-4c00-8569-fc7dd2ac2244" />


After:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/7b617edf-441c-44cf-9fe2-944ba1cf51e3" />



