### PR TITLE
feat: add daily view granularity and gross/nett view mode for income page 

### DIFF
--- a/src/lib/income.ts
+++ b/src/lib/income.ts
@@ -6,6 +6,7 @@ import {
   formatCurrencyCrude,
   type Income,
   type Posting,
+  type Tax,
   restName,
   secondName,
   skipTicks,
@@ -89,6 +90,21 @@ export function renderDailyInvestmentTimeline(
   return renderIncomeTimeline(dailyIncomes, "#d3-income-timeline", "DD-MMM");
 }
 
+export function renderMonthlyNetIncomeTimeline(incomes: Income[], taxes: any[]): Legend[] {
+  const netIncomes = calculateNetIncomeMonthly(incomes, taxes);
+  return renderIncomeTimeline(netIncomes, "#d3-income-timeline", "MMM-YYYY");
+}
+
+export function renderDailyNetIncomeTimeline(
+  incomes: Income[],
+  taxes: any[],
+  year: number,
+  month: number
+): Legend[] {
+  const netIncomes = calculateNetIncomeDaily(incomes, taxes, year, month);
+  return renderIncomeTimeline(netIncomes, "#d3-income-timeline", "DD-MMM");
+}
+
 function transformToDailyData(incomes: Income[], year: number, month: number): Income[] {
   const targetDate = dayjs()
     .year(year)
@@ -125,6 +141,118 @@ function transformToDailyData(incomes: Income[], year: number, month: number): I
   }
 
   return dailyIncomes;
+}
+
+function calculateNetIncomeMonthly(incomes: Income[], taxes: Tax[]): Income[] {
+  // Create a map of tax amounts by month
+  const taxByMonth = new Map<string, number>();
+
+  taxes.forEach((tax) => {
+    const monthKey = dayjs(tax.start_date).format("YYYY-MM");
+    const taxAmount = _.sumBy(tax.postings, (p: Posting) => p.amount);
+    taxByMonth.set(monthKey, (taxByMonth.get(monthKey) || 0) + taxAmount);
+  });
+
+  // Calculate net income for each month (income - tax)
+  return incomes.map((income) => {
+    const monthKey = dayjs(income.date).format("YYYY-MM");
+    const grossIncomeAmount = _.sumBy(income.postings, (p) => -p.amount);
+    const taxAmount = taxByMonth.get(monthKey) || 0;
+    const netIncomeAmount = grossIncomeAmount - taxAmount;
+
+    // Create a synthetic posting for net income
+    const basePosting = income.postings[0] || {
+      id: "net-income",
+      date: income.date,
+      payee: "Net Income",
+      account: "Income:Net",
+      commodity: "INR",
+      quantity: 0,
+      amount: 0,
+      status: "",
+      tag_recurring: "",
+      transaction_begin_line: 0,
+      transaction_end_line: 0,
+      file_name: "",
+      note: "",
+      transaction_note: "",
+      market_amount: 0,
+      balance: 0
+    };
+
+    const netPosting: Posting = {
+      ...basePosting,
+      amount: -netIncomeAmount, // Negative because income is typically negative in the system
+      account: "Income:Net"
+    };
+
+    return {
+      date: income.date,
+      postings: [netPosting]
+    };
+  });
+}
+
+function calculateNetIncomeDaily(
+  incomes: Income[],
+  taxes: Tax[],
+  year: number,
+  month: number
+): Income[] {
+  // First get daily income data
+  const dailyIncomes = transformToDailyData(incomes, year, month);
+
+  // Create a map of tax amounts by day for the specified month
+  const taxByDay = new Map<string, number>();
+
+  taxes.forEach((tax) => {
+    tax.postings.forEach((posting: Posting) => {
+      const postingDate = dayjs(posting.date);
+      if (postingDate.year() === year && postingDate.month() === month - 1) {
+        const dayKey = postingDate.format("YYYY-MM-DD");
+        taxByDay.set(dayKey, (taxByDay.get(dayKey) || 0) + posting.amount);
+      }
+    });
+  });
+
+  // Calculate net income for each day (income - tax)
+  return dailyIncomes.map((income) => {
+    const dayKey = dayjs(income.date).format("YYYY-MM-DD");
+    const grossIncomeAmount = _.sumBy(income.postings, (p) => -p.amount);
+    const taxAmount = taxByDay.get(dayKey) || 0;
+    const netIncomeAmount = grossIncomeAmount - taxAmount;
+
+    // Create a synthetic posting for net income
+    const basePosting = income.postings[0] || {
+      id: "net-income",
+      date: income.date,
+      payee: "Net Income",
+      account: "Income:Net",
+      commodity: "INR",
+      quantity: 0,
+      amount: 0,
+      status: "",
+      tag_recurring: "",
+      transaction_begin_line: 0,
+      transaction_end_line: 0,
+      file_name: "",
+      note: "",
+      transaction_note: "",
+      market_amount: 0,
+      balance: 0
+    };
+
+    const netPosting: Posting = {
+      ...basePosting,
+      amount: -netIncomeAmount, // Negative because income is typically negative in the system
+      account: "Income:Net"
+    };
+
+    return {
+      date: income.date,
+      postings: [netPosting]
+    };
+  });
 }
 
 function renderIncomeTimeline(incomes: Income[], id: string, timeFormat: string): Legend[] {

--- a/src/lib/income.ts
+++ b/src/lib/income.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import type dayjs from "dayjs";
+import dayjs, { type Dayjs } from "dayjs";
 import _ from "lodash";
 import {
   formatCurrency,
@@ -77,6 +77,54 @@ function createYearlyTooltipContent(
 
 export function renderMonthlyInvestmentTimeline(incomes: Income[]): Legend[] {
   return renderIncomeTimeline(incomes, "#d3-income-timeline", "MMM-YYYY");
+}
+
+export function renderDailyInvestmentTimeline(
+  incomes: Income[],
+  year: number,
+  month: number
+): Legend[] {
+  // Transform monthly data to daily data for the specified month
+  const dailyIncomes = transformToDailyData(incomes, year, month);
+  return renderIncomeTimeline(dailyIncomes, "#d3-income-timeline", "DD-MMM");
+}
+
+function transformToDailyData(incomes: Income[], year: number, month: number): Income[] {
+  const targetDate = dayjs()
+    .year(year)
+    .month(month - 1); // dayjs months are 0-indexed
+  const startOfMonth = targetDate.startOf("month");
+  const endOfMonth = targetDate.endOf("month");
+  const daysInMonth = endOfMonth.date();
+
+  // Find all postings for the target month
+  const monthlyPostings = _.flatMap(incomes, (income) => {
+    const incomeDate = dayjs(income.date);
+    if (incomeDate.year() === year && incomeDate.month() === month - 1) {
+      return income.postings.map((posting) => ({
+        ...posting,
+        date: dayjs(posting.date)
+      }));
+    }
+    return [];
+  });
+
+  // Group postings by day
+  const postingsByDay = _.groupBy(monthlyPostings, (posting) => dayjs(posting.date).date());
+
+  // Create daily income objects for each day of the month
+  const dailyIncomes: Income[] = [];
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dayDate = startOfMonth.date(day);
+    const dayPostings = postingsByDay[day] || [];
+
+    dailyIncomes.push({
+      date: dayDate,
+      postings: dayPostings
+    });
+  }
+
+  return dailyIncomes;
 }
 
 function renderIncomeTimeline(incomes: Income[], id: string, timeFormat: string): Legend[] {


### PR DESCRIPTION
Before this change, the income page shows income with **monthly-granularity**. My use-case includes multiple income streams throughout a month where a **daily-granularity** would benefit.
Additionally, I added gross|nett mode for the income graph to show nett income chart. This serves as an alternative to the _/cash_flow/monthly_ page to see nett income progress.

Changelog:
1. Add **monthly|daily** toggle button. Toggling **daily** would cause a MonthPicker to show up, to choose which month to show at daily granularity. Rendering the chart at per-day granularity throughout the chosen month (e.g. to see which day had spiked in income)
2. Add **gross|nett** mode for the income page. Nett mode shows `sum(income) - sum(tax)` for each bars (per-day or per-month).


Preview (1):
![20251004-154820](https://github.com/user-attachments/assets/9f4a3568-d352-4ad1-9938-51dbf9777dd5)

Preview (2):
<img width="2536" height="1087" alt="image" src="https://github.com/user-attachments/assets/799a7f35-e184-49d0-8d96-0d0631dae1d3" />
<img width="2514" height="1076" alt="image" src="https://github.com/user-attachments/assets/af4d704e-944a-47d3-8727-2c02d596b540" />

