### PR TITLE
fix: sort descending income chart tooltip and show only filtered item

### DIFF
--- a/src/lib/repayment.ts
+++ b/src/lib/repayment.ts
@@ -151,13 +151,15 @@ export function renderMonthlyRepaymentTimelineWithFilter(
               );
               const total = _.sumBy(filteredPostings, (p) => p.amount);
               return tooltip(
-                _.sortBy(
-                  filteredPostings.map((p) => [
-                    _.drop(p.account.split(":")).join(":"),
-                    [formatCurrency(p.amount), "has-text-weight-bold has-text-right"]
-                  ]),
-                  (r) => r[0]
-                ),
+                _.orderBy(
+                  filteredPostings.map((p) => ({
+                    account: _.drop(p.account.split(":")).join(":"),
+                    formatted: [formatCurrency(p.amount), "has-text-weight-bold has-text-right"],
+                    amount: p.amount
+                  })),
+                  "amount",
+                  "desc"
+                ).map((item) => [item.account, item.formatted]),
                 {
                   total: formatCurrency(total),
                   header: date.format("MMM YYYY")
@@ -187,13 +189,15 @@ export function renderMonthlyRepaymentTimelineWithFilter(
               );
               const total = _.sumBy(filteredPostings, (p) => p.amount);
               return tooltip(
-                _.sortBy(
-                  filteredPostings.map((p) => [
-                    _.drop(p.account.split(":")).join(":"),
-                    [formatCurrency(p.amount), "has-text-weight-bold has-text-right"]
-                  ]),
-                  (r) => r[0]
-                ),
+                _.orderBy(
+                  filteredPostings.map((p) => ({
+                    account: _.drop(p.account.split(":")).join(":"),
+                    formatted: [formatCurrency(p.amount), "has-text-weight-bold has-text-right"],
+                    amount: p.amount
+                  })),
+                  "amount",
+                  "desc"
+                ).map((item) => [item.account, item.formatted]),
                 {
                   total: formatCurrency(total),
                   header: date.format("MMM YYYY")
@@ -347,13 +351,15 @@ export function renderMonthlyRepaymentTimeline(postings: Posting[]): Legend[] {
       const date = (d.data as any).date;
       const total = _.sumBy(postings, (p) => p.amount);
       return tooltip(
-        _.sortBy(
-          postings.map((p) => [
-            _.drop(p.account.split(":")).join(":"),
-            [formatCurrency(p.amount), "has-text-weight-bold has-text-right"]
-          ]),
-          (r) => r[0]
-        ),
+        _.orderBy(
+          postings.map((p) => ({
+            account: _.drop(p.account.split(":")).join(":"),
+            formatted: [formatCurrency(p.amount), "has-text-weight-bold has-text-right"],
+            amount: p.amount
+          })),
+          "amount",
+          "desc"
+        ).map((item) => [item.account, item.formatted]),
         {
           total: formatCurrency(total),
           header: date.format("MMM YYYY")

--- a/src/routes/(app)/expense/yearly/+page.svelte
+++ b/src/routes/(app)/expense/yearly/+page.svelte
@@ -161,7 +161,7 @@
             <strong>Oops!</strong> You have no expenses.
           </ZeroState>
 
-          <LegendCard {legends} clazz="ml-4" />
+          <LegendCard {legends} clazz="ml-4 overflow-x-auto" />
           <svg id="d3-yearly-expense-timeline" width="100%" height="500" />
         </div>
       </div>


### PR DESCRIPTION
Changelog:
1. Sort income tooltip descending by amount.
2. Show only filtered legend item on income chart tooltip, instead of still showing all items.

Preview (1 & 2):
Before:
<img width="2008" height="1222" alt="image" src="https://github.com/user-attachments/assets/22f29d56-047b-48d1-ab42-3b23126386f0" />

After:
<img width="1112" height="1116" alt="image" src="https://github.com/user-attachments/assets/4698e035-66d2-4537-9148-ffbfba23dff1" />
