### PR TITLE
feat: improve balance table view

### DIFF
--- a/src/lib/components/MultiSelectDropdown.svelte
+++ b/src/lib/components/MultiSelectDropdown.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let options: string[] = [];
+  export let selectedItems: Set<string> = new Set();
+  export let placeholder: string = "Select items...";
+  export let maxDisplayItems: number = 3;
+
+  const dispatch = createEventDispatcher<{
+    change: { selectedItems: Set<string> };
+  }>();
+
+  let isOpen = false;
+  let searchTerm = "";
+  let dropdownElement: HTMLElement;
+
+  // Filter options based on search term
+  $: filteredOptions = options.filter((option) =>
+    option.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  // Display text for the dropdown button
+  $: displayText = getDisplayText();
+
+  function getDisplayText(): string {
+    if (selectedItems.size === 0) {
+      return placeholder;
+    }
+
+    if (selectedItems.size <= maxDisplayItems) {
+      return Array.from(selectedItems).join(", ");
+    }
+
+    const firstItems = Array.from(selectedItems).slice(0, maxDisplayItems);
+    return `${firstItems.join(", ")} +${selectedItems.size - maxDisplayItems} more`;
+  }
+
+  function toggleItem(item: string) {
+    const newSelectedItems = new Set(selectedItems);
+
+    if (newSelectedItems.has(item)) {
+      newSelectedItems.delete(item);
+    } else {
+      newSelectedItems.add(item);
+    }
+
+    selectedItems = newSelectedItems;
+    dispatch("change", { selectedItems: newSelectedItems });
+  }
+
+  function selectAll() {
+    selectedItems = new Set(filteredOptions);
+    dispatch("change", { selectedItems });
+  }
+
+  function clearAll() {
+    // Keep only the first item checked
+    const firstItem = filteredOptions.length > 0 ? filteredOptions[0] : null;
+    selectedItems = firstItem ? new Set([firstItem]) : new Set();
+    dispatch("change", { selectedItems });
+  }
+
+  function handleClickOutside(event: MouseEvent) {
+    if (dropdownElement && !dropdownElement.contains(event.target as Node)) {
+      isOpen = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      isOpen = false;
+    }
+  }
+</script>
+
+<svelte:window on:click={handleClickOutside} on:keydown={handleKeydown} />
+
+<div class="dropdown" class:is-active={isOpen} bind:this={dropdownElement}>
+  <div class="dropdown-trigger">
+    <button
+      class="button is-small"
+      aria-haspopup="true"
+      aria-controls="dropdown-menu"
+      on:click={() => (isOpen = !isOpen)}
+    >
+      <span class="dropdown-text">{displayText}</span>
+      <span class="icon is-small">
+        <i class="fas fa-angle-down" class:rotated={isOpen}></i>
+      </span>
+    </button>
+  </div>
+
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <!-- Search input -->
+      <div class="dropdown-item p-2">
+        <input
+          class="input is-small"
+          type="text"
+          placeholder="Search accounts..."
+          bind:value={searchTerm}
+          on:click|stopPropagation
+        />
+      </div>
+
+      <!-- Action buttons -->
+      <div class="dropdown-item p-2">
+        <div class="buttons are-small">
+          <button class="button is-small is-light" on:click={selectAll}> Select All </button>
+          <button class="button is-small is-light" on:click={clearAll}> Clear All </button>
+        </div>
+      </div>
+
+      <hr class="dropdown-divider" />
+
+      <!-- Options list -->
+      <div class="dropdown-options">
+        {#each filteredOptions as option}
+          <label class="dropdown-item checkbox-item">
+            <input
+              type="checkbox"
+              checked={selectedItems.has(option)}
+              on:change={() => toggleItem(option)}
+              on:click|stopPropagation
+            />
+            <span class="checkbox-text">{option}</span>
+          </label>
+        {/each}
+      </div>
+
+      {#if filteredOptions.length === 0}
+        <div class="dropdown-item has-text-grey">No accounts found</div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .dropdown {
+    position: relative;
+  }
+
+  .dropdown-text {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    margin-right: 0.5rem;
+  }
+
+  .icon i.rotated {
+    transform: rotate(180deg);
+  }
+
+  .dropdown-menu {
+    min-width: 300px;
+    max-width: 400px;
+  }
+
+  .dropdown-options {
+    max-height: 300px;
+    overflow-y: auto;
+  }
+
+  .checkbox-item {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+  }
+
+  .checkbox-item:hover {
+    background-color: #f5f5f5;
+  }
+
+  .checkbox-item input[type="checkbox"] {
+    margin-right: 0.5rem;
+    cursor: pointer;
+  }
+
+  .checkbox-text {
+    flex: 1;
+    font-size: 0.875rem;
+    line-height: 1.2;
+    word-break: break-all;
+  }
+
+  .buttons {
+    gap: 0.5rem;
+  }
+
+  /* Dark theme support */
+  :global(html[data-theme="dark"]) .checkbox-item:hover {
+    background-color: #4a4a4a;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-content {
+    background-color: #363636;
+    color: #f5f5f5;
+  }
+
+  :global(html[data-theme="dark"]) .input {
+    background-color: #4a4a4a;
+    border-color: #5a5a5a;
+    color: #f5f5f5;
+  }
+
+  :global(html[data-theme="dark"]) .button.is-light {
+    background-color: #4a4a4a;
+    border-color: #5a5a5a;
+    color: #f5f5f5;
+  }
+
+  :global(html[data-theme="dark"]) .button.is-light:hover {
+    background-color: #5a5a5a;
+  }
+</style>

--- a/src/lib/components/MultiSelectDropdown.svelte
+++ b/src/lib/components/MultiSelectDropdown.svelte
@@ -193,27 +193,42 @@
 
   /* Dark theme support */
   :global(html[data-theme="dark"]) .checkbox-item:hover {
-    background-color: #4a4a4a;
+    background-color: #2a2a2a;
   }
 
   :global(html[data-theme="dark"]) .dropdown-content {
-    background-color: #363636;
+    background-color: #1a1a1a;
     color: #f5f5f5;
+    border: 1px solid #333;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-menu {
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
   }
 
   :global(html[data-theme="dark"]) .input {
-    background-color: #4a4a4a;
-    border-color: #5a5a5a;
+    background-color: #2a2a2a;
+    border-color: #444;
     color: #f5f5f5;
   }
 
+  :global(html[data-theme="dark"]) .input:focus {
+    border-color: #3273dc;
+    box-shadow: 0 0 0 0.125em rgba(50, 115, 220, 0.25);
+  }
+
   :global(html[data-theme="dark"]) .button.is-light {
-    background-color: #4a4a4a;
-    border-color: #5a5a5a;
+    background-color: #2a2a2a;
+    border-color: #444;
     color: #f5f5f5;
   }
 
   :global(html[data-theme="dark"]) .button.is-light:hover {
-    background-color: #5a5a5a;
+    background-color: #333;
+    border-color: #555;
+  }
+
+  :global(html[data-theme="dark"]) .dropdown-divider {
+    background-color: #444;
   }
 </style>

--- a/src/routes/(app)/assets/balance/+page.svelte
+++ b/src/routes/(app)/assets/balance/+page.svelte
@@ -110,7 +110,7 @@
           <div class="action-buttons mb-4">
             <div class="is-flex is-align-items-center is-justify-content-flex-start pr-3 pl-3">
               <!-- Hide empty checkbox -->
-              <div class="field">
+              <div class="field is-flex is-align-items-center">
                 <label class="checkbox modern-checkbox">
                   <input type="checkbox" bind:checked={hideEmptyMarketValue} />
                   <span class="checkmark"></span>
@@ -146,6 +146,13 @@
     cursor: pointer;
     font-size: 0.9rem;
     user-select: none;
+    height: 32px;
+    margin-bottom: 0;
+  }
+
+  /* Ensure field containers don't have default margins */
+  .field {
+    margin-bottom: 0;
   }
 
   .modern-checkbox input[type="checkbox"] {


### PR DESCRIPTION
Changelog:
1. Fix: re-calculate parent rows when some child rows are hidden by hide-row checkbox.
2. Feat: add dropdown containing filters for assets shown in the balance table.

Preview (1):
Before:
<img width="1496" height="816" alt="image" src="https://github.com/user-attachments/assets/26499e4a-077a-4347-8094-2fef171a6498" />

After:
<img width="1550" height="536" alt="image" src="https://github.com/user-attachments/assets/f904e4a4-3351-4571-87f1-701310037e6c" />

Preview (2):
<img width="1608" height="1146" alt="image" src="https://github.com/user-attachments/assets/718ed64a-a2d9-4543-beb5-2e6fec0003cb" />

