### PR TITLE
fix: correct regression on the calculation for absolute return column

### DIFF
--- a/src/routes/(app)/assets/balance/+page.svelte
+++ b/src/routes/(app)/assets/balance/+page.svelte
@@ -188,11 +188,10 @@
               : 0,
           absoluteReturn:
             parentTotals.investmentAmount > 0
-              ? ((parentTotals.marketAmount -
+              ? (parentTotals.marketAmount -
                   parentTotals.investmentAmount +
                   parentTotals.withdrawalAmount) /
-                  parentTotals.investmentAmount) *
-                100
+                parentTotals.investmentAmount
               : 0
         };
       }


### PR DESCRIPTION
There was a regression during hide-empty feature implemention, causing the absolute return calculation to be excessive (incorrect).